### PR TITLE
Add Aleo Cryptography Reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 
 members = [
+    "applied-crypto-references/aleo-cryptography",
     "applied-crypto-references",
     "applied-crypto-references/curve-operations",
     "applied-crypto-references/merlin-transcripts",
     "applied-crypto-references/zksnarks",
-    "proving-libraries"
 ]

--- a/applied-crypto-references/aleo-cryptography/Cargo.toml
+++ b/applied-crypto-references/aleo-cryptography/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "aleo-cryptography"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+snarkvm = { version = "0.9.13", features = [ "utilities", "curves" ] }

--- a/applied-crypto-references/aleo-cryptography/src/algebra.rs
+++ b/applied-crypto-references/aleo-cryptography/src/algebra.rs
@@ -1,0 +1,29 @@
+///! This module explores Aleo's basic algebraic structures and their properties
+
+//Field and Ring elements
+use snarkvm::utilities::{
+    BigInteger384, BigInteger
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn additions_overflow() {
+        let mut a = BigInteger384::new([u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX]);
+        let mut b = BigInteger384::from(7);
+        a.add_nocarry(&b);
+        let d = BigInteger384::from(6);
+        assert_eq!(a, d);
+    }
+
+    #[test]
+    fn subs_overflow() {
+        let mut a = BigInteger384::from(0);
+        let mut b = BigInteger384::from(1);
+        a.sub_noborrow(&b);
+        let d = BigInteger384::new([u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX]);
+        assert_eq!(a, d);
+    }
+}

--- a/applied-crypto-references/aleo-cryptography/src/lib.rs
+++ b/applied-crypto-references/aleo-cryptography/src/lib.rs
@@ -1,0 +1,1 @@
+mod algebra;


### PR DESCRIPTION
## Motivation

Aleo's SnarkVM provides a set of extraordinary cryptographic primitives for achieving ZkSnarks. This crate provides an exploration of those primitives.